### PR TITLE
Revert "chore(deps): bump androidx.biometric:biometric-ktx from 1.2.0-alpha05 to 1.4.0-alpha01"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ work = "2.9.0"
 recyclerview = "1.3.2"
 preference = "1.2.1"
 room = "2.6.1"
-biometric = "1.4.0-alpha01"
+biometric = "1.2.0-alpha05"
 color-chooser = "0.7.3"
 composeAndroid = "1.6.7"
 


### PR DESCRIPTION
Reverts DroidWorksStudio/EasyLauncher#53