### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/validate-gradle-wrapper.yml
+++ b/.github/workflows/validate-gradle-wrapper.yml
@@ -17,4 +17,4 @@ jobs:
       - uses: actions/checkout@v4.1.7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: gradle/wrapper-validation-action@v3.4.2
+      - uses: gradle/wrapper-validation-action@v3.5.0


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[gradle/wrapper-validation-action](https://github.com/gradle/wrapper-validation-action)** published a new release **[v3.5.0](https://github.com/gradle/wrapper-validation-action/releases/tag/v3.5.0)** on 2024-07-15T19:31:50Z
