### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/android-branch_ci.yml
+++ b/.github/workflows/android-branch_ci.yml
@@ -19,7 +19,7 @@ jobs:
           token: ${{ secrets.GIT_BOT_TOKEN }}
 
       - name: set up JDK 17
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@v4.2.2
         with:
           java-version: "17"
           distribution: "temurin"
@@ -44,14 +44,14 @@ jobs:
         run: ./gradlew clean && ./gradlew assembleWithInternetDebug && ./gradlew assembleWithoutInternetDebug
 
       - name: Upload Artifact - WithInternet
-        uses: actions/upload-artifact@v4.3.5
+        uses: actions/upload-artifact@v4.3.6
         with:
           name: Signed app bundle - WithInternet
           path: app/build/outputs/apk/withInternet/debug/*.apk
           retention-days: 3
 
       - name: Upload Artifact - WithoutInternet
-        uses: actions/upload-artifact@v4.3.5
+        uses: actions/upload-artifact@v4.3.6
         with:
           name: Signed app bundle - WithoutInternet
           path: app/build/outputs/apk/withoutInternet/debug/*.apk

--- a/.github/workflows/android-main_ci.yml
+++ b/.github/workflows/android-main_ci.yml
@@ -17,7 +17,7 @@ jobs:
           token: ${{ secrets.GIT_BOT_TOKEN }}
 
       - name: set up JDK 17
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@v4.2.2
         with:
           java-version: "17"
           distribution: "temurin"
@@ -42,14 +42,14 @@ jobs:
         run: ./gradlew clean && ./gradlew assembleWithInternetDebug && ./gradlew assembleWithoutInternetDebug
 
       - name: Upload Artifact - WithInternet
-        uses: actions/upload-artifact@v4.3.5
+        uses: actions/upload-artifact@v4.3.6
         with:
           name: Signed app bundle - WithInternet
           path: app/build/outputs/apk/withInternet/debug/*.apk
           retention-days: 3
 
       - name: Upload Artifact - WithoutInternet
-        uses: actions/upload-artifact@v4.3.5
+        uses: actions/upload-artifact@v4.3.6
         with:
           name: Signed app bundle - WithoutInternet
           path: app/build/outputs/apk/withoutInternet/debug/*.apk

--- a/.github/workflows/android-pr_ci.yml
+++ b/.github/workflows/android-pr_ci.yml
@@ -17,7 +17,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: set up JDK 17
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@v4.2.2
         with:
           java-version: "17"
           distribution: "temurin"
@@ -42,14 +42,14 @@ jobs:
         run: ./gradlew clean && ./gradlew assembleWithInternetDebug && ./gradlew assembleWithoutInternetDebug
 
       - name: Upload Artifact - WithInternet
-        uses: actions/upload-artifact@v4.3.5
+        uses: actions/upload-artifact@v4.3.6
         with:
           name: Signed app bundle - WithInternet
           path: app/build/outputs/apk/withInternet/debug/*.apk
           retention-days: 3
 
       - name: Upload Artifact - WithoutInternet
-        uses: actions/upload-artifact@v4.3.5
+        uses: actions/upload-artifact@v4.3.6
         with:
           name: Signed app bundle - WithoutInternet
           path: app/build/outputs/apk/withoutInternet/debug/*.apk

--- a/.github/workflows/android-release_ci-forced.yml
+++ b/.github/workflows/android-release_ci-forced.yml
@@ -14,7 +14,7 @@ jobs:
           token: ${{ secrets.GIT_BOT_TOKEN }}
 
       - name: set up JDK 17
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@v4.2.2
         with:
           java-version: "17"
           distribution: "temurin"
@@ -51,7 +51,7 @@ jobs:
           buildToolsVersion: 33.0.0
 
       - name: Upload Artifact - WithInternet
-        uses: actions/upload-artifact@v4.3.5
+        uses: actions/upload-artifact@v4.3.6
         with:
           name: Signed app bundle - WithInternet
           path: app/build/outputs/apk/withInternet/release/*.apk
@@ -70,7 +70,7 @@ jobs:
           buildToolsVersion: 33.0.0
 
       - name: Upload Artifact - WithoutInternet
-        uses: actions/upload-artifact@v4.3.5
+        uses: actions/upload-artifact@v4.3.6
         with:
           name: Signed app bundle - WithoutInternet
           path: app/build/outputs/apk/withoutInternet/release/*.apk

--- a/.github/workflows/android-release_ci.yml
+++ b/.github/workflows/android-release_ci.yml
@@ -17,7 +17,7 @@ jobs:
           token: ${{ secrets.GIT_BOT_TOKEN }}
 
       - name: set up JDK 17
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@v4.2.2
         with:
           java-version: "17"
           distribution: "temurin"

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -46,7 +46,7 @@ jobs:
           token: ${{ secrets.GIT_BOT_TOKEN }}
 
       - name: set up JDK 17
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@v4.2.2
         with:
           java-version: "17"
           distribution: "temurin"


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v4.2.2](https://github.com/actions/setup-java/releases/tag/v4.2.2)** on 2024-08-05T14:04:36Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.3.6](https://github.com/actions/upload-artifact/releases/tag/v4.3.6)** on 2024-08-06T14:41:41Z
