### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/android-branch_ci.yml
+++ b/.github/workflows/android-branch_ci.yml
@@ -19,7 +19,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: set up JDK 17
-        uses: actions/setup-java@v4.2.2
+        uses: actions/setup-java@v4.3.0
         with:
           java-version: "17"
           distribution: "temurin"
@@ -44,14 +44,14 @@ jobs:
         run: ./gradlew clean && ./gradlew assembleWithInternetDebug && ./gradlew assembleWithoutInternetDebug
 
       - name: Upload Artifact - WithInternet
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: Signed app bundle - WithInternet
           path: app/build/outputs/apk/withInternet/debug/*.apk
           retention-days: 3
 
       - name: Upload Artifact - WithoutInternet
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: Signed app bundle - WithoutInternet
           path: app/build/outputs/apk/withoutInternet/debug/*.apk

--- a/.github/workflows/android-main_ci.yml
+++ b/.github/workflows/android-main_ci.yml
@@ -17,7 +17,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: set up JDK 17
-        uses: actions/setup-java@v4.2.2
+        uses: actions/setup-java@v4.3.0
         with:
           java-version: "17"
           distribution: "temurin"
@@ -42,14 +42,14 @@ jobs:
         run: ./gradlew clean && ./gradlew assembleWithInternetDebug && ./gradlew assembleWithoutInternetDebug
 
       - name: Upload Artifact - WithInternet
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: Signed app bundle - WithInternet
           path: app/build/outputs/apk/withInternet/debug/*.apk
           retention-days: 3
 
       - name: Upload Artifact - WithoutInternet
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: Signed app bundle - WithoutInternet
           path: app/build/outputs/apk/withoutInternet/debug/*.apk

--- a/.github/workflows/android-pr_ci.yml
+++ b/.github/workflows/android-pr_ci.yml
@@ -17,7 +17,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: set up JDK 17
-        uses: actions/setup-java@v4.2.2
+        uses: actions/setup-java@v4.3.0
         with:
           java-version: "17"
           distribution: "temurin"
@@ -42,14 +42,14 @@ jobs:
         run: ./gradlew clean && ./gradlew assembleWithInternetDebug && ./gradlew assembleWithoutInternetDebug
 
       - name: Upload Artifact - WithInternet
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: Signed app bundle - WithInternet
           path: app/build/outputs/apk/withInternet/debug/*.apk
           retention-days: 3
 
       - name: Upload Artifact - WithoutInternet
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: Signed app bundle - WithoutInternet
           path: app/build/outputs/apk/withoutInternet/debug/*.apk

--- a/.github/workflows/android-release_ci-forced.yml
+++ b/.github/workflows/android-release_ci-forced.yml
@@ -14,7 +14,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: set up JDK 17
-        uses: actions/setup-java@v4.2.2
+        uses: actions/setup-java@v4.3.0
         with:
           java-version: "17"
           distribution: "temurin"
@@ -51,7 +51,7 @@ jobs:
           buildToolsVersion: 33.0.0
 
       - name: Upload Artifact - WithInternet
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: Signed app bundle - WithInternet
           path: app/build/outputs/apk/withInternet/release/*.apk
@@ -70,7 +70,7 @@ jobs:
           buildToolsVersion: 33.0.0
 
       - name: Upload Artifact - WithoutInternet
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: Signed app bundle - WithoutInternet
           path: app/build/outputs/apk/withoutInternet/release/*.apk

--- a/.github/workflows/android-release_ci.yml
+++ b/.github/workflows/android-release_ci.yml
@@ -17,7 +17,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: set up JDK 17
-        uses: actions/setup-java@v4.2.2
+        uses: actions/setup-java@v4.3.0
         with:
           java-version: "17"
           distribution: "temurin"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Generate a changelog
-        uses: orhun/git-cliff-action@v3.3.0
+        uses: orhun/git-cliff-action@v4.0.2
         with:
           config: cliff.toml
           args: --verbose

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -46,7 +46,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: set up JDK 17
-        uses: actions/setup-java@v4.2.2
+        uses: actions/setup-java@v4.3.0
         with:
           java-version: "17"
           distribution: "temurin"


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[orhun/git-cliff-action](https://github.com/orhun/git-cliff-action)** published a new release **[v4.0.2](https://github.com/orhun/git-cliff-action/releases/tag/v4.0.2)** on 2024-09-04T16:38:44Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v4.3.0](https://github.com/actions/setup-java/releases/tag/v4.3.0)** on 2024-09-09T14:25:53Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.4.0](https://github.com/actions/upload-artifact/releases/tag/v4.4.0)** on 2024-08-30T18:10:56Z
