### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -109,7 +109,7 @@ jobs:
         shell: bash
 
       - name: Create and Upload Release
-        uses: softprops/action-gh-release@v2.0.9
+        uses: softprops/action-gh-release@v2.1.0
         with:
           tag_name: nightly
           name: Nightly Release ${{ env.version }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[softprops/action-gh-release](https://github.com/softprops/action-gh-release)** published a new release **[v2.1.0](https://github.com/softprops/action-gh-release/releases/tag/v2.1.0)** on 2024-11-11T20:16:36Z
