### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/close-inactive-issues_ci.yml
+++ b/.github/workflows/close-inactive-issues_ci.yml
@@ -12,7 +12,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v9.0.0
+      - uses: actions/stale@v9.1.0
         with:
           days-before-issue-stale: 30
           days-before-issue-close: 14


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/stale](https://github.com/actions/stale)** published a new release **[v9.1.0](https://github.com/actions/stale/releases/tag/v9.1.0)** on 2025-01-21T03:34:36Z
