### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/android-branch_ci.yml
+++ b/.github/workflows/android-branch_ci.yml
@@ -25,7 +25,7 @@ jobs:
           distribution: "temurin"
           cache: gradle
 
-      - uses: actions/cache@v4.2.0
+      - uses: actions/cache@v4.2.1
         with:
           path: |
             ~/.gradle/caches
@@ -44,14 +44,14 @@ jobs:
         run: ./gradlew clean && ./gradlew assembleWithInternetDebug && ./gradlew assembleWithoutInternetDebug
 
       - name: Upload Artifact - WithInternet
-        uses: actions/upload-artifact@v4.6.0
+        uses: actions/upload-artifact@v4.6.1
         with:
           name: Signed app bundle - WithInternet
           path: app/build/outputs/apk/withInternet/debug/*.apk
           retention-days: 3
 
       - name: Upload Artifact - WithoutInternet
-        uses: actions/upload-artifact@v4.6.0
+        uses: actions/upload-artifact@v4.6.1
         with:
           name: Signed app bundle - WithoutInternet
           path: app/build/outputs/apk/withoutInternet/debug/*.apk

--- a/.github/workflows/android-main_ci.yml
+++ b/.github/workflows/android-main_ci.yml
@@ -23,7 +23,7 @@ jobs:
           distribution: "temurin"
           cache: gradle
 
-      - uses: actions/cache@v4.2.0
+      - uses: actions/cache@v4.2.1
         with:
           path: |
             ~/.gradle/caches
@@ -42,14 +42,14 @@ jobs:
         run: ./gradlew clean && ./gradlew assembleWithInternetDebug && ./gradlew assembleWithoutInternetDebug
 
       - name: Upload Artifact - WithInternet
-        uses: actions/upload-artifact@v4.6.0
+        uses: actions/upload-artifact@v4.6.1
         with:
           name: Signed app bundle - WithInternet
           path: app/build/outputs/apk/withInternet/debug/*.apk
           retention-days: 3
 
       - name: Upload Artifact - WithoutInternet
-        uses: actions/upload-artifact@v4.6.0
+        uses: actions/upload-artifact@v4.6.1
         with:
           name: Signed app bundle - WithoutInternet
           path: app/build/outputs/apk/withoutInternet/debug/*.apk

--- a/.github/workflows/android-pr_ci.yml
+++ b/.github/workflows/android-pr_ci.yml
@@ -23,7 +23,7 @@ jobs:
           distribution: "temurin"
           cache: gradle
 
-      - uses: actions/cache@v4.2.0
+      - uses: actions/cache@v4.2.1
         with:
           path: |
             ~/.gradle/caches
@@ -42,14 +42,14 @@ jobs:
         run: ./gradlew clean && ./gradlew assembleWithInternetDebug && ./gradlew assembleWithoutInternetDebug
 
       - name: Upload Artifact - WithInternet
-        uses: actions/upload-artifact@v4.6.0
+        uses: actions/upload-artifact@v4.6.1
         with:
           name: Signed app bundle - WithInternet
           path: app/build/outputs/apk/withInternet/debug/*.apk
           retention-days: 3
 
       - name: Upload Artifact - WithoutInternet
-        uses: actions/upload-artifact@v4.6.0
+        uses: actions/upload-artifact@v4.6.1
         with:
           name: Signed app bundle - WithoutInternet
           path: app/build/outputs/apk/withoutInternet/debug/*.apk

--- a/.github/workflows/android-release_ci-forced.yml
+++ b/.github/workflows/android-release_ci-forced.yml
@@ -20,7 +20,7 @@ jobs:
           distribution: "temurin"
           cache: gradle
 
-      - uses: actions/cache@v4.2.0
+      - uses: actions/cache@v4.2.1
         with:
           path: |
             ~/.gradle/caches
@@ -51,7 +51,7 @@ jobs:
           buildToolsVersion: 35.0.0
 
       - name: Upload Artifact - WithInternet
-        uses: actions/upload-artifact@v4.6.0
+        uses: actions/upload-artifact@v4.6.1
         with:
           name: Signed app bundle - WithInternet
           path: app/build/outputs/apk/withInternet/release/*.apk
@@ -70,7 +70,7 @@ jobs:
           buildToolsVersion: 35.0.0
 
       - name: Upload Artifact - WithoutInternet
-        uses: actions/upload-artifact@v4.6.0
+        uses: actions/upload-artifact@v4.6.1
         with:
           name: Signed app bundle - WithoutInternet
           path: app/build/outputs/apk/withoutInternet/release/*.apk

--- a/.github/workflows/android-release_ci.yml
+++ b/.github/workflows/android-release_ci.yml
@@ -23,7 +23,7 @@ jobs:
           distribution: "temurin"
           cache: gradle
 
-      - uses: actions/cache@v4.2.0
+      - uses: actions/cache@v4.2.1
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -52,7 +52,7 @@ jobs:
           distribution: "temurin"
           cache: gradle
 
-      - uses: actions/cache@v4.2.0
+      - uses: actions/cache@v4.2.1
         with:
           path: |
             ~/.gradle/caches


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.2.1](https://github.com/actions/cache/releases/tag/v4.2.1)** on 2025-02-18T17:44:12Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.6.1](https://github.com/actions/upload-artifact/releases/tag/v4.6.1)** on 2025-02-21T19:00:26Z
