### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/android-branch_ci.yml
+++ b/.github/workflows/android-branch_ci.yml
@@ -25,7 +25,7 @@ jobs:
           distribution: "temurin"
           cache: gradle
 
-      - uses: actions/cache@v4.2.1
+      - uses: actions/cache@v4.2.2
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/android-main_ci.yml
+++ b/.github/workflows/android-main_ci.yml
@@ -23,7 +23,7 @@ jobs:
           distribution: "temurin"
           cache: gradle
 
-      - uses: actions/cache@v4.2.1
+      - uses: actions/cache@v4.2.2
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/android-pr_ci.yml
+++ b/.github/workflows/android-pr_ci.yml
@@ -23,7 +23,7 @@ jobs:
           distribution: "temurin"
           cache: gradle
 
-      - uses: actions/cache@v4.2.1
+      - uses: actions/cache@v4.2.2
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/android-release_ci-forced.yml
+++ b/.github/workflows/android-release_ci-forced.yml
@@ -20,7 +20,7 @@ jobs:
           distribution: "temurin"
           cache: gradle
 
-      - uses: actions/cache@v4.2.1
+      - uses: actions/cache@v4.2.2
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/android-release_ci.yml
+++ b/.github/workflows/android-release_ci.yml
@@ -23,7 +23,7 @@ jobs:
           distribution: "temurin"
           cache: gradle
 
-      - uses: actions/cache@v4.2.1
+      - uses: actions/cache@v4.2.2
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -52,7 +52,7 @@ jobs:
           distribution: "temurin"
           cache: gradle
 
-      - uses: actions/cache@v4.2.1
+      - uses: actions/cache@v4.2.2
         with:
           path: |
             ~/.gradle/caches


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.2.2](https://github.com/actions/cache/releases/tag/v4.2.2)** on 2025-02-27T14:49:12Z
