### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v6.2.0
+        uses: crazy-max/ghaction-import-gpg@v6.3.0
         with:
           gpg_private_key: ${{ secrets.GIT_ACTIONS_GPG_KEY }}
           git_user_signingkey: true


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[crazy-max/ghaction-import-gpg](https://github.com/crazy-max/ghaction-import-gpg)** published a new release **[v6.3.0](https://github.com/crazy-max/ghaction-import-gpg/releases/tag/v6.3.0)** on 2025-03-29T23:16:53Z
