### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/android-branch_ci.yml
+++ b/.github/workflows/android-branch_ci.yml
@@ -19,7 +19,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: set up JDK 17
-        uses: actions/setup-java@v4.7.0
+        uses: actions/setup-java@v4.7.1
         with:
           java-version: "17"
           distribution: "temurin"

--- a/.github/workflows/android-main_ci.yml
+++ b/.github/workflows/android-main_ci.yml
@@ -17,7 +17,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: set up JDK 17
-        uses: actions/setup-java@v4.7.0
+        uses: actions/setup-java@v4.7.1
         with:
           java-version: "17"
           distribution: "temurin"

--- a/.github/workflows/android-pr_ci.yml
+++ b/.github/workflows/android-pr_ci.yml
@@ -17,7 +17,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: set up JDK 17
-        uses: actions/setup-java@v4.7.0
+        uses: actions/setup-java@v4.7.1
         with:
           java-version: "17"
           distribution: "temurin"

--- a/.github/workflows/android-release_ci-forced.yml
+++ b/.github/workflows/android-release_ci-forced.yml
@@ -14,7 +14,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: set up JDK 17
-        uses: actions/setup-java@v4.7.0
+        uses: actions/setup-java@v4.7.1
         with:
           java-version: "17"
           distribution: "temurin"
@@ -39,7 +39,7 @@ jobs:
         run: ./gradlew clean && ./gradlew assembleWithInternetRelease && ./gradlew assembleWithoutInternetRelease
 
       - name: Sign APK - WithInternet
-        uses: ilharp/sign-android-release@v1.0.4
+        uses: ilharp/sign-android-release@v2.0.0
         # ID used to access action output
         id: sign_app_withInternet
         with:
@@ -58,7 +58,7 @@ jobs:
           retention-days: 3
 
       - name: Sign APK - WithoutInternet
-        uses: ilharp/sign-android-release@v1.0.4
+        uses: ilharp/sign-android-release@v2.0.0
         # ID used to access action output
         id: sign_app_withoutInternet
         with:

--- a/.github/workflows/android-release_ci.yml
+++ b/.github/workflows/android-release_ci.yml
@@ -17,7 +17,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: set up JDK 17
-        uses: actions/setup-java@v4.7.0
+        uses: actions/setup-java@v4.7.1
         with:
           java-version: "17"
           distribution: "temurin"
@@ -42,7 +42,7 @@ jobs:
         run: ./gradlew clean && ./gradlew assembleWithInternetRelease && ./gradlew assembleWithoutInternetRelease
 
       - name: Sign APK - WithInternet
-        uses: ilharp/sign-android-release@v1.0.4
+        uses: ilharp/sign-android-release@v2.0.0
         # ID used to access action output
         id: sign_app_withInternet
         with:
@@ -63,7 +63,7 @@ jobs:
           overwrite: true
 
       - name: Sign APK - WithoutInternet
-        uses: ilharp/sign-android-release@v1.0.4
+        uses: ilharp/sign-android-release@v2.0.0
         # ID used to access action output
         id: sign_app_withoutInternet
         with:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v6.2.0
+        uses: crazy-max/ghaction-import-gpg@v6.3.0
         with:
           gpg_private_key: ${{ secrets.GIT_ACTIONS_GPG_KEY }}
           git_user_signingkey: true

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -46,7 +46,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: set up JDK 17
-        uses: actions/setup-java@v4.7.0
+        uses: actions/setup-java@v4.7.1
         with:
           java-version: "17"
           distribution: "temurin"
@@ -71,7 +71,7 @@ jobs:
         run: ./gradlew clean && ./gradlew assembleWithInternetNightlyRelease && ./gradlew assembleWithoutInternetNightlyRelease
 
       - name: Sign APK - WithInternet
-        uses: ilharp/sign-android-release@v1.0.4
+        uses: ilharp/sign-android-release@v2.0.0
         # ID used to access action output
         id: sign_app_withInternet
         with:
@@ -83,7 +83,7 @@ jobs:
           buildToolsVersion: 35.0.0
 
       - name: Sign APK - WithoutInternet
-        uses: ilharp/sign-android-release@v1.0.4
+        uses: ilharp/sign-android-release@v2.0.0
         # ID used to access action output
         id: sign_app_withoutInternet
         with:
@@ -109,7 +109,7 @@ jobs:
         shell: bash
 
       - name: Create and Upload Release
-        uses: softprops/action-gh-release@v2.2.1
+        uses: softprops/action-gh-release@v2.2.2
         with:
           tag_name: nightly
           name: Nightly Release ${{ env.version }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[crazy-max/ghaction-import-gpg](https://github.com/crazy-max/ghaction-import-gpg)** published a new release **[v6.3.0](https://github.com/crazy-max/ghaction-import-gpg/releases/tag/v6.3.0)** on 2025-03-29T23:16:53Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v4.7.1](https://github.com/actions/setup-java/releases/tag/v4.7.1)** on 2025-04-09T02:58:20Z
* **[softprops/action-gh-release](https://github.com/softprops/action-gh-release)** published a new release **[v2.2.2](https://github.com/softprops/action-gh-release/releases/tag/v2.2.2)** on 2025-04-18T21:34:22Z
* **[ilharp/sign-android-release](https://github.com/ilharp/sign-android-release)** published a new release **[v2.0.0](https://github.com/ilharp/sign-android-release/releases/tag/v2.0.0)** on 2025-04-18T01:19:37Z
