### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/android-release_ci.yml
+++ b/.github/workflows/android-release_ci.yml
@@ -54,7 +54,7 @@ jobs:
           buildToolsVersion: 35.0.0
 
       - name: Release to GitHub - WithInternet
-        uses: svenstaro/upload-release-action@2.9.0
+        uses: svenstaro/upload-release-action@2.11.1
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ${{steps.sign_app_withInternet.outputs.signedFile}}
@@ -75,7 +75,7 @@ jobs:
           buildToolsVersion: 35.0.0
 
       - name: Release to GitHub  - WithoutInternet
-        uses: svenstaro/upload-release-action@2.9.0
+        uses: svenstaro/upload-release-action@2.11.1
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ${{steps.sign_app_withoutInternet.outputs.signedFile}}

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -109,7 +109,7 @@ jobs:
         shell: bash
 
       - name: Create and Upload Release
-        uses: softprops/action-gh-release@v2.2.2
+        uses: softprops/action-gh-release@v2.3.2
         with:
           tag_name: nightly
           name: Nightly Release ${{ env.version }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[svenstaro/upload-release-action](https://github.com/svenstaro/upload-release-action)** published a new release **[2.11.1](https://github.com/svenstaro/upload-release-action/releases/tag/2.11.1)** on 2025-06-30T21:00:45Z
* **[softprops/action-gh-release](https://github.com/softprops/action-gh-release)** published a new release **[v2.3.2](https://github.com/softprops/action-gh-release/releases/tag/v2.3.2)** on 2025-06-10T22:33:54Z
